### PR TITLE
Improve UI and parse multiple slurm jobs

### DIFF
--- a/slurm_dashboard/scheduler.py
+++ b/slurm_dashboard/scheduler.py
@@ -56,11 +56,14 @@ class SlurmScheduler(Scheduler):
             'TimeLimit',
             'TimeUsed',
         ]
-        command = f"squeue --noheader -O {','.join(cols)} --me"
+        delimiter = '|'
+        command = (
+            f"squeue --noheader --delimiter={delimiter} -O {','.join(cols)} --me"
+        )
         output = self._run(command)
         jobs: List[Job] = []
         for line in output.splitlines():
-            parts = line.split()
+            parts = [p.strip() for p in line.split(delimiter)]
             if len(parts) < len(cols):
                 continue
             job_id, name, state, nodelist, queue, tl, tu = parts[:7]

--- a/slurm_dashboard/templates/file_view.html
+++ b/slurm_dashboard/templates/file_view.html
@@ -1,9 +1,17 @@
 <!doctype html>
-<html>
-<head><title>{{ file_type.capitalize() }} for Job {{ job_id }}</title></head>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ file_type.capitalize() }} for Job {{ job_id }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        pre { background: #f9f9f9; padding: 1em; border: 1px solid #ccc; }
+        a { display: inline-block; margin-top: 1em; }
+    </style>
+</head>
 <body>
     <h1>{{ file_type.capitalize() }} for Job {{ job_id }}</h1>
     <pre>{{ content }}</pre>
-    <p><a href="{{ url_for('index') }}">Back</a></p>
+    <a href="{{ url_for('index') }}">Back</a>
 </body>
 </html>

--- a/slurm_dashboard/templates/index.html
+++ b/slurm_dashboard/templates/index.html
@@ -1,7 +1,18 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
-    <title>Slurm Jobs</title>
+    <meta charset="utf-8">
+    <title>Slurm Jobs Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1em; }
+        th, td { padding: 0.5em; border: 1px solid #ccc; text-align: left; }
+        th { background-color: #f0f0f0; }
+        .actions form { display: inline; margin: 0; }
+        .actions a { margin-left: 0.5em; }
+        .flash-success { color: green; }
+        .flash-error { color: red; }
+    </style>
 </head>
 <body>
     <h1>Slurm Job Queue</h1>
@@ -10,15 +21,25 @@
     {% if messages %}
     <ul>
         {% for category, message in messages %}
-        <li><strong>{{ category }}</strong>: {{ message }}</li>
+        <li class="flash-{{ category }}">{{ message }}</li>
         {% endfor %}
     </ul>
     {% endif %}
     {% endwith %}
-    <table border="1" cellpadding="5" cellspacing="0">
+    <table>
+        <thead>
         <tr>
-            <th>ID</th><th>Name</th><th>Status</th><th>Queue</th><th>NodeList</th><th>Time Used</th><th>Time Limit</th><th>Actions</th>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Queue</th>
+            <th>NodeList</th>
+            <th>Time Used</th>
+            <th>Time Limit</th>
+            <th>Actions</th>
         </tr>
+        </thead>
+        <tbody>
         {% for job in jobs %}
         <tr>
             <td>{{ job.id }}</td>
@@ -28,8 +49,8 @@
             <td>{{ job.node_list }}</td>
             <td>{{ job.cur_time }}</td>
             <td>{{ job.max_time }}</td>
-            <td>
-                <form action="{{ url_for('cancel', job_id=job.id) }}" method="post" style="display:inline">
+            <td class="actions">
+                <form action="{{ url_for('cancel', job_id=job.id) }}" method="post">
                     <button type="submit">Cancel</button>
                 </form>
                 <a href="{{ url_for('output', job_id=job.id) }}">Output</a>
@@ -37,6 +58,7 @@
             </td>
         </tr>
         {% endfor %}
+        </tbody>
     </table>
 </body>
 </html>

--- a/slurm_dashboard/templates/submit.html
+++ b/slurm_dashboard/templates/submit.html
@@ -1,12 +1,25 @@
 <!doctype html>
-<html>
-<head><title>Submit Job</title></head>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Submit Job</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        form { margin-top: 1em; }
+        label { display: block; margin-bottom: 0.5em; }
+        input[type=text] { width: 100%; padding: 0.5em; }
+        button { margin-top: 0.5em; }
+        a { display: inline-block; margin-top: 1em; }
+    </style>
+</head>
 <body>
     <h1>Submit Job Script</h1>
     <form method="post">
-        <label>Script path: <input type="text" name="script"></label>
+        <label>Script path:
+            <input type="text" name="script">
+        </label>
         <button type="submit">Submit</button>
     </form>
-    <p><a href="{{ url_for('index') }}">Back</a></p>
+    <a href="{{ url_for('index') }}">Back</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance look & feel of pages with some minimal CSS
- parse `squeue` output with a delimiter so all jobs are shown

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688337e984b88328bee593cfe2ff97e8