### PR TITLE
Fix Slurm delimiter quoting

### DIFF
--- a/slurm_dashboard/scheduler.py
+++ b/slurm_dashboard/scheduler.py
@@ -56,10 +56,11 @@ class SlurmScheduler(Scheduler):
             'TimeLimit',
             'TimeUsed',
         ]
-        delimiter = '|'
-        command = (
-            f"squeue --noheader --delimiter={delimiter} -O {','.join(cols)} --me"
-        )
+        # Older Slurm versions do not support the ``--delimiter`` option.
+        # Use a custom format string instead and split on a known character.
+        delimiter = "|"
+        fmt = "%i|%j|%T|%N|%P|%l|%M"
+        command = f"squeue --noheader -o '{fmt}' --me"
         output = self._run(command)
         jobs: List[Job] = []
         for line in output.splitlines():


### PR DESCRIPTION
## Summary
- fix quoting of pipe delimiter for `squeue` command

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883420bf4388328a99aad44d065b53c