### PR TITLE
Add read-only mode via disable job submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project provides a simple Flask based dashboard for monitoring Slurm jobs. 
 - Cancel running jobs
 - Submit new job scripts
 - View job stdout and stderr files
+- Optionally disable job submission for read-only mode
 
 ## Usage
 
@@ -23,6 +24,8 @@ pip install -r requirements.txt
 export FLASK_APP=slurm_dashboard.app
 # Use debug scheduler if you do not have access to Slurm
 export SCHEDULER_BACKEND=debug
+# Disable job submission by setting this to 0 or "false"
+export ENABLE_JOB_SUBMISSION=1
 flask run
 ```
 

--- a/slurm_dashboard/templates/index.html
+++ b/slurm_dashboard/templates/index.html
@@ -16,7 +16,9 @@
 </head>
 <body>
     <h1>Slurm Job Queue</h1>
+    {% if submission_enabled %}
     <p><a href="{{ url_for('submit') }}">Submit new job</a></p>
+    {% endif %}
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
     <ul>


### PR DESCRIPTION
## Summary
- allow disabling job submission via `ENABLE_JOB_SUBMISSION` env var
- show submit link only when job submission is enabled
- document the new variable in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883458b944c83288f8c21bf71e602fa