### PR TITLE
Implement login before dashboard access

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project provides a simple Flask based dashboard for monitoring Slurm jobs. 
 - Cancel running jobs
 - Submit new job scripts
 - View job stdout and stderr files
+- Password protected access to the dashboard
 
 ## Usage
 
@@ -23,6 +24,7 @@ pip install -r requirements.txt
 export FLASK_APP=slurm_dashboard.app
 # Use debug scheduler if you do not have access to Slurm
 export SCHEDULER_BACKEND=debug
+export DASHBOARD_PASSWORD=mysecret  # optional, defaults to 'admin'
 flask run
 ```
 

--- a/slurm_dashboard/templates/index.html
+++ b/slurm_dashboard/templates/index.html
@@ -16,7 +16,10 @@
 </head>
 <body>
     <h1>Slurm Job Queue</h1>
-    <p><a href="{{ url_for('submit') }}">Submit new job</a></p>
+    <p>
+        <a href="{{ url_for('submit') }}">Submit new job</a> |
+        <a href="{{ url_for('logout') }}">Logout</a>
+    </p>
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
     <ul>

--- a/slurm_dashboard/templates/login.html
+++ b/slurm_dashboard/templates/login.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Login</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        form { margin-top: 1em; }
+        label { display: block; margin-bottom: 0.5em; }
+        input[type=password] { width: 100%; padding: 0.5em; }
+        button { margin-top: 0.5em; }
+        .flash-success { color: green; }
+        .flash-error { color: red; }
+    </style>
+</head>
+<body>
+    <h1>Login</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <ul>
+        {% for category, message in messages %}
+        <li class="flash-{{ category }}">{{ message }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    {% endwith %}
+    <form method="post">
+        <label>Password:
+            <input type="password" name="password" autofocus>
+        </label>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- secure dashboard with login-required decorator
- add login and logout routes
- provide login page template
- add Logout link to dashboard
- mention password option in README

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68834b70f4d083288e4f9d9136615e73