### PR TITLE
Add job history viewer with filters

### DIFF
--- a/slurm_dashboard/templates/history.html
+++ b/slurm_dashboard/templates/history.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Job History</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1em; }
+        th, td { padding: 0.5em; border: 1px solid #ccc; text-align: left; }
+        th { background-color: #f0f0f0; }
+        form { margin-bottom: 1em; }
+    </style>
+</head>
+<body>
+    <h1>Past Jobs</h1>
+    <form method="get">
+        <label>Range:
+            <select name="range">
+                <option value="">Custom</option>
+                <option value="1d">Last day</option>
+                <option value="1w">Last week</option>
+            </select>
+        </label>
+        <label>Start:
+            <input type="date" name="start" value="{{ start }}">
+        </label>
+        <label>End:
+            <input type="date" name="end" value="{{ end }}">
+        </label>
+        <label>Status:
+            <select name="status">
+                <option value="" {% if not status %}selected{% endif %}>All</option>
+                <option value="COMPLETED" {% if status=='COMPLETED' %}selected{% endif %}>COMPLETED</option>
+                <option value="FAILED" {% if status=='FAILED' %}selected{% endif %}>FAILED</option>
+                <option value="CANCELLED" {% if status=='CANCELLED' %}selected{% endif %}>CANCELLED</option>
+                <option value="TIMEOUT" {% if status=='TIMEOUT' %}selected{% endif %}>TIMEOUT</option>
+            </select>
+        </label>
+        <button type="submit">Apply</button>
+        <a href="{{ url_for('index') }}">Back</a>
+    </form>
+    <table>
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Queue</th>
+            <th>NodeList</th>
+            <th>Start</th>
+            <th>End</th>
+            <th>Exit Code</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for job in jobs %}
+        <tr>
+            <td>{{ job.id }}</td>
+            <td>{{ job.name }}</td>
+            <td>{{ job.status }}</td>
+            <td>{{ job.queue }}</td>
+            <td>{{ job.node_list }}</td>
+            <td>{{ job.start_time }}</td>
+            <td>{{ job.end_time }}</td>
+            <td>{{ job.exit_code }}</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/slurm_dashboard/templates/index.html
+++ b/slurm_dashboard/templates/index.html
@@ -20,6 +20,7 @@
         {% if submission_enabled %}
         <a href="{{ url_for('submit') }}">Submit new job</a> |
         {% endif %}
+        <a href="{{ url_for('history') }}">Past jobs</a> |
         <a href="{{ url_for('logout') }}">Logout</a>
     </p>
     {% with messages = get_flashed_messages(with_categories=true) %}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -7,3 +7,17 @@ def test_debug_scheduler_cancel():
     job = sched.get_queue()[0]
     sched.cancel_job(job)
     assert len(sched.get_queue()) == initial - 1
+
+
+def test_debug_scheduler_history_filter():
+    sched = DebugScheduler()
+    hist = sched.get_history(states=["COMPLETED"])
+    assert all(j.status == "COMPLETED" for j in hist)
+    assert len(hist) == 1
+
+
+def test_debug_scheduler_history_all():
+    sched = DebugScheduler()
+    hist = sched.get_history()
+    statuses = {j.status for j in hist}
+    assert {"COMPLETED", "TIMEOUT", "CANCELLED", "FAILED"}.issubset(statuses)


### PR DESCRIPTION
## Summary
- add fields to Job for history information
- implement `get_history` in scheduler classes
- expose `/history` route to view finished jobs
- create history template with date and status filters
- add link to history page from job queue
- test new scheduler history methods

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68874f0a2b948328b1b6b32708bb0c1a