### PR TITLE
Improve error feedback for job history

### DIFF
--- a/slurm_dashboard/app.py
+++ b/slurm_dashboard/app.py
@@ -59,7 +59,11 @@ def logout():
 @app.route('/')
 @login_required
 def index():
-    jobs = scheduler.get_queue()
+    try:
+        jobs = scheduler.get_queue()
+    except RuntimeError as e:
+        flash(str(e) or 'Failed to retrieve job queue', 'error')
+        jobs = []
     return render_template('index.html', jobs=jobs, submission_enabled=SUBMISSION_ENABLED)
 
 
@@ -76,7 +80,11 @@ def history():
         start = (datetime.utcnow() - timedelta(days=1)).strftime('%Y-%m-%d')
     elif range_sel == '1w':
         start = (datetime.utcnow() - timedelta(days=7)).strftime('%Y-%m-%d')
-    jobs = scheduler.get_history(start, end, [status] if status else None)
+    try:
+        jobs = scheduler.get_history(start, end, [status] if status else None)
+    except RuntimeError as e:
+        flash(str(e) or 'Failed to retrieve job history', 'error')
+        jobs = []
     return render_template(
         'history.html',
         jobs=jobs,

--- a/slurm_dashboard/templates/history.html
+++ b/slurm_dashboard/templates/history.html
@@ -9,10 +9,21 @@
         th, td { padding: 0.5em; border: 1px solid #ccc; text-align: left; }
         th { background-color: #f0f0f0; }
         form { margin-bottom: 1em; }
+        .flash-success { color: green; }
+        .flash-error { color: red; }
     </style>
 </head>
 <body>
     <h1>Past Jobs</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <ul>
+        {% for category, message in messages %}
+        <li class="flash-{{ category }}">{{ message }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    {% endwith %}
     <form method="get">
         <label>Range:
             <select name="range">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,47 @@
+import importlib
+app_module = importlib.import_module('slurm_dashboard.app')
+
+class FailingScheduler:
+    def get_queue(self):
+        raise RuntimeError('queue error')
+
+    def get_history(self, *args, **kwargs):
+        raise RuntimeError('history error')
+
+    def cancel_job(self, job):
+        pass
+
+    def submit_job(self, script):
+        pass
+
+    def get_job_output_path(self, job):
+        return None
+
+    def get_job_error_path(self, job):
+        return None
+
+
+def _login(client):
+    return client.post('/login', data={'password': 'admin'})
+
+
+def test_index_handles_scheduler_error(monkeypatch):
+    monkeypatch.setattr(app_module, 'scheduler', FailingScheduler())
+    app_module.app.testing = True
+    client = app_module.app.test_client()
+    with client:
+        _login(client)
+        resp = client.get('/')
+        assert resp.status_code == 200
+        assert b'queue error' in resp.data
+
+
+def test_history_handles_scheduler_error(monkeypatch):
+    monkeypatch.setattr(app_module, 'scheduler', FailingScheduler())
+    app_module.app.testing = True
+    client = app_module.app.test_client()
+    with client:
+        _login(client)
+        resp = client.get('/history')
+        assert resp.status_code == 200
+        assert b'history error' in resp.data


### PR DESCRIPTION
## Summary
- flash errors if the scheduler backend fails for job queue or history
- display flash messages on the history page
- test scheduler error handling for index and history routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688750bfbd548328a6f09deb44910aca