### PR TITLE
Improve past jobs UI and add pagination

### DIFF
--- a/slurm_dashboard/templates/file_view.html
+++ b/slurm_dashboard/templates/file_view.html
@@ -4,14 +4,16 @@
     <meta charset="utf-8">
     <title>{{ file_type.capitalize() }} for Job {{ job_id }}</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 2em; }
+        body { font-family: Arial, sans-serif; margin: 2em; background-color:#f8f9fa; }
         pre { background: #f9f9f9; padding: 1em; border: 1px solid #ccc; }
         a { display: inline-block; margin-top: 1em; }
+        .btn { background-color: #007bff; color:#fff; padding:0.3em 0.6em; border:none; border-radius:4px; text-decoration:none; }
+        .btn:hover { background-color:#0056b3; }
     </style>
 </head>
 <body>
     <h1>{{ file_type.capitalize() }} for Job {{ job_id }}</h1>
     <pre>{{ content }}</pre>
-    <a href="{{ url_for('index') }}">Back</a>
+    <a class="btn" href="{{ url_for('index') }}">Back</a>
 </body>
 </html>

--- a/slurm_dashboard/templates/history.html
+++ b/slurm_dashboard/templates/history.html
@@ -4,13 +4,16 @@
     <meta charset="utf-8">
     <title>Job History</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 2em; }
+        body { font-family: Arial, sans-serif; margin: 2em; background-color:#f8f9fa; }
         table { width: 100%; border-collapse: collapse; margin-top: 1em; }
-        th, td { padding: 0.5em; border: 1px solid #ccc; text-align: left; }
-        th { background-color: #f0f0f0; }
+        th, td { padding: 0.5em; border: 1px solid #dee2e6; text-align: left; }
+        th { background-color: #343a40; color: #fff; }
         form { margin-bottom: 1em; }
         .flash-success { color: green; }
         .flash-error { color: red; }
+        .btn { background-color: #007bff; color:#fff; padding:0.3em 0.6em; border:none; border-radius:4px; text-decoration:none; }
+        .btn:hover { background-color:#0056b3; }
+        .table-container { max-height:60vh; overflow-y:auto; }
     </style>
 </head>
 <body>
@@ -47,9 +50,10 @@
                 <option value="TIMEOUT" {% if status=='TIMEOUT' %}selected{% endif %}>TIMEOUT</option>
             </select>
         </label>
-        <button type="submit">Apply</button>
-        <a href="{{ url_for('index') }}">Back</a>
+        <button class="btn" type="submit">Apply</button>
+        <a class="btn" href="{{ url_for('index') }}">Back</a>
     </form>
+    <div class="table-container">
     <table>
         <thead>
         <tr>
@@ -78,5 +82,14 @@
         {% endfor %}
         </tbody>
     </table>
+    </div>
+    <p>
+        {% if prev_url %}
+        <a class="btn" href="{{ prev_url }}">Previous</a>
+        {% endif %}
+        {% if next_url %}
+        <a class="btn" href="{{ next_url }}">Next</a>
+        {% endif %}
+    </p>
 </body>
 </html>

--- a/slurm_dashboard/templates/index.html
+++ b/slurm_dashboard/templates/index.html
@@ -4,24 +4,27 @@
     <meta charset="utf-8">
     <title>Slurm Jobs Dashboard</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 2em; }
+        body { font-family: Arial, sans-serif; margin: 2em; background-color:#f8f9fa; }
         table { width: 100%; border-collapse: collapse; margin-top: 1em; }
-        th, td { padding: 0.5em; border: 1px solid #ccc; text-align: left; }
-        th { background-color: #f0f0f0; }
+        th, td { padding: 0.5em; border: 1px solid #dee2e6; text-align: left; }
+        th { background-color: #343a40; color: #fff; }
         .actions form { display: inline; margin: 0; }
         .actions a { margin-left: 0.5em; }
         .flash-success { color: green; }
         .flash-error { color: red; }
+        .btn { background-color: #007bff; color:#fff; padding:0.3em 0.6em; border:none; border-radius:4px; text-decoration:none; }
+        .btn:hover { background-color:#0056b3; }
+        .table-container { max-height:60vh; overflow-y:auto; }
     </style>
 </head>
 <body>
     <h1>Slurm Job Queue</h1>
     <p>
         {% if submission_enabled %}
-        <a href="{{ url_for('submit') }}">Submit new job</a> |
+        <a class="btn" href="{{ url_for('submit') }}">Submit new job</a> |
         {% endif %}
-        <a href="{{ url_for('history') }}">Past jobs</a> |
-        <a href="{{ url_for('logout') }}">Logout</a>
+        <a class="btn" href="{{ url_for('history') }}">Past jobs</a> |
+        <a class="btn" href="{{ url_for('logout') }}">Logout</a>
     </p>
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -32,6 +35,7 @@
     </ul>
     {% endif %}
     {% endwith %}
+    <div class="table-container">
     <table>
         <thead>
         <tr>
@@ -57,14 +61,15 @@
             <td>{{ job.max_time }}</td>
             <td class="actions">
                 <form action="{{ url_for('cancel', job_id=job.id) }}" method="post">
-                    <button type="submit">Cancel</button>
+                    <button class="btn" type="submit">Cancel</button>
                 </form>
-                <a href="{{ url_for('output', job_id=job.id) }}">Output</a>
-                <a href="{{ url_for('error', job_id=job.id) }}">Error</a>
+                <a class="btn" href="{{ url_for('output', job_id=job.id) }}">Output</a>
+                <a class="btn" href="{{ url_for('error', job_id=job.id) }}">Error</a>
             </td>
         </tr>
         {% endfor %}
         </tbody>
     </table>
+    </div>
 </body>
 </html>

--- a/slurm_dashboard/templates/login.html
+++ b/slurm_dashboard/templates/login.html
@@ -4,13 +4,15 @@
     <meta charset="utf-8">
     <title>Login</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 2em; }
+        body { font-family: Arial, sans-serif; margin: 2em; background-color:#f8f9fa; }
         form { margin-top: 1em; }
         label { display: block; margin-bottom: 0.5em; }
         input[type=password] { width: 100%; padding: 0.5em; }
         button { margin-top: 0.5em; }
         .flash-success { color: green; }
         .flash-error { color: red; }
+        .btn { background-color: #007bff; color:#fff; padding:0.3em 0.6em; border:none; border-radius:4px; text-decoration:none; }
+        .btn:hover { background-color:#0056b3; }
     </style>
 </head>
 <body>
@@ -28,7 +30,7 @@
         <label>Password:
             <input type="password" name="password" autofocus>
         </label>
-        <button type="submit">Login</button>
+        <button class="btn" type="submit">Login</button>
     </form>
 </body>
 </html>

--- a/slurm_dashboard/templates/submit.html
+++ b/slurm_dashboard/templates/submit.html
@@ -4,12 +4,14 @@
     <meta charset="utf-8">
     <title>Submit Job</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 2em; }
+        body { font-family: Arial, sans-serif; margin: 2em; background-color:#f8f9fa; }
         form { margin-top: 1em; }
         label { display: block; margin-bottom: 0.5em; }
         input[type=text] { width: 100%; padding: 0.5em; }
         button { margin-top: 0.5em; }
         a { display: inline-block; margin-top: 1em; }
+        .btn { background-color: #007bff; color:#fff; padding:0.3em 0.6em; border:none; border-radius:4px; text-decoration:none; }
+        .btn:hover { background-color:#0056b3; }
     </style>
 </head>
 <body>
@@ -18,8 +20,8 @@
         <label>Script path:
             <input type="text" name="script">
         </label>
-        <button type="submit">Submit</button>
+        <button class="btn" type="submit">Submit</button>
     </form>
-    <a href="{{ url_for('index') }}">Back</a>
+    <a class="btn" href="{{ url_for('index') }}">Back</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- filter out common batch job names from history view
- add pagination and table scrolling to the job history
- enhance page styling and buttons across templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875c38f4dc8328b98f04c9a0564a3c