### PR TITLE
Add run duration column to history

### DIFF
--- a/slurm_dashboard/templates/history.html
+++ b/slurm_dashboard/templates/history.html
@@ -64,6 +64,7 @@
             <th>NodeList</th>
             <th>Start</th>
             <th>End</th>
+            <th>RunDuration</th>
             <th>Exit Code</th>
         </tr>
         </thead>
@@ -77,6 +78,7 @@
             <td>{{ job.node_list }}</td>
             <td>{{ job.start_time }}</td>
             <td>{{ job.end_time }}</td>
+            <td>{{ job.run_duration }}</td>
             <td>{{ job.exit_code }}</td>
         </tr>
         {% endfor %}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -45,3 +45,4 @@ def test_slurm_scheduler_history_parsing(monkeypatch):
     assert job.start_time == "2025-07-28T01:00:00"
     assert job.end_time == "2025-07-28T02:00:00"
     assert job.exit_code == "0:0"
+    assert job.run_duration == "1:00:00"


### PR DESCRIPTION
## Summary
- compute job runtime from start/end timestamps
- show RunDuration in past job history
- test SlurmScheduler runtime parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68887241bf8c8328ae4bc750d53f705b