### PR TITLE
Add job details page with StdOut/StdErr links

### DIFF
--- a/slurm_dashboard/templates/details.html
+++ b/slurm_dashboard/templates/details.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Job {{ job_id }} Details</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; background-color:#f8f9fa; }
+        pre { background: #f9f9f9; padding: 1em; border: 1px solid #ccc; }
+        .btn { background-color: #007bff; color:#fff; padding:0.3em 0.6em; border:none; border-radius:4px; text-decoration:none; }
+        .btn:hover { background-color:#0056b3; }
+    </style>
+</head>
+<body>
+    <h1>Job {{ job_id }} Details</h1>
+    <pre>{{ details }}</pre>
+    {% if stdout_exists %}
+    <a class="btn" href="{{ url_for('output', job_id=job_id) }}">StdOut</a>
+    {% endif %}
+    {% if stderr_exists %}
+    <a class="btn" href="{{ url_for('error', job_id=job_id) }}">StdErr</a>
+    {% endif %}
+    <a class="btn" href="{{ url_for('history') }}">Back</a>
+</body>
+</html>

--- a/slurm_dashboard/templates/history.html
+++ b/slurm_dashboard/templates/history.html
@@ -66,6 +66,7 @@
             <th>End</th>
             <th>RunDuration</th>
             <th>Exit Code</th>
+            <th>Details</th>
         </tr>
         </thead>
         <tbody>
@@ -80,6 +81,7 @@
             <td>{{ job.end_time }}</td>
             <td>{{ job.run_duration }}</td>
             <td>{{ job.exit_code }}</td>
+            <td><a class="btn" href="{{ url_for('details', job_id=job.id) }}">Details</a></td>
         </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- add Scheduler.get_job_details for retrieving raw `scontrol` output
- implement details route and template
- allow output/error routes to work with finished jobs
- expose details button in past jobs table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888897754088328a1181740b43bdd8e